### PR TITLE
Add support for Spring Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,7 @@
 		<dependency>
 			<groupId>com.vladsch.flexmark</groupId>
 			<artifactId>flexmark-all</artifactId>
-			<version>0.35.4</version>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
+			<version>0.35.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/src/main/java/io/pivotal/jira/JiraConfig.java
+++ b/src/main/java/io/pivotal/jira/JiraConfig.java
@@ -22,6 +22,7 @@ import lombok.Data;
 
 /**
  * @author Rob Winch
+ * @author Artem Bilan
  *
  */
 @Component
@@ -55,6 +56,7 @@ public class JiraConfig {
 	String password;
 
 	public String getMigrateJql() {
-		return migrateJql == null ? "project = " + getProjectId() + " ORDER BY key ASC" : migrateJql;
+		return this.migrateJql == null ? "project = '" + getProjectId() + "' ORDER BY key ASC" : this.migrateJql;
 	}
+
 }

--- a/src/main/java/io/pivotal/migration/MigrationClient.java
+++ b/src/main/java/io/pivotal/migration/MigrationClient.java
@@ -211,12 +211,11 @@ public class  MigrationClient {
 				getRest().exchange(requestBuilder.body(map), MAP_TYPE);
 			}
 			catch (HttpClientErrorException.UnprocessableEntity ex) {
-				// The milestone already exists on GH, so swallow its error and continue
-				if (ex.getMessage() != null && !ex.getMessage().contains("already_exists")) {
-					throw ex;
+				if (ex.getMessage() != null && ex.getMessage().contains("already_exists")) {
+					logger.info("Milestone '{}' exists; ignore", version.getName());
 				}
 				else {
-					logger.info("Milestone '{}' exists; ignore", version.getName());
+					throw ex;
 				}
 			}
 		}
@@ -237,12 +236,11 @@ public class  MigrationClient {
 				getRest().exchange(bodyBuilder.body(map), MAP_TYPE);
 			}
 			catch (HttpClientErrorException.UnprocessableEntity ex) {
-				// The milestone already exists on GH, so swallow its error and continue
-				if (ex.getMessage() != null && !ex.getMessage().contains("already_exists")) {
-					throw ex;
+				if (ex.getMessage() != null && ex.getMessage().contains("already_exists")) {
+					logger.info("Label '{}' exists; ignore", map.get("name"));
 				}
 				else {
-					logger.info("Label '{}' exists; ignore", map.get("name"));
+					throw ex;
 				}
 			}
 

--- a/src/main/java/io/pivotal/migration/MigrationClient.java
+++ b/src/main/java/io/pivotal/migration/MigrationClient.java
@@ -68,6 +68,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -76,6 +77,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 /**
  * @author Rob Winch
  * @author Rossen Stoyanchev
+ * @author Artem Bilan
  */
 @Data
 @Component
@@ -86,10 +88,10 @@ public class  MigrationClient {
 	private static final List<String> SUPPRESSED_LINK_TYPES = Arrays.asList("relates to", "is related to");
 
 	private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
-			new ParameterizedTypeReference<Map<String, Object>>() {};
+			new ParameterizedTypeReference<>() {};
 
 	private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_OF_MAPS_TYPE =
-			new ParameterizedTypeReference<List<Map<String, Object>>>() {};
+			new ParameterizedTypeReference<>() {};
 
 	private static final String GITHUB_URL = "https://api.github.com";
 
@@ -205,7 +207,18 @@ public class  MigrationClient {
 			if (version.getReleaseDate() != null) {
 				map.put("due_on", version.getReleaseDate().toString(dateTimeFormatter));
 			}
-			this.getRest().exchange(requestBuilder.body(map), MAP_TYPE);
+			try {
+				getRest().exchange(requestBuilder.body(map), MAP_TYPE);
+			}
+			catch (HttpClientErrorException.UnprocessableEntity ex) {
+				// The milestone already exists on GH, so swallow its error and continue
+				if (ex.getMessage() != null && !ex.getMessage().contains("already_exists")) {
+					throw ex;
+				}
+				else {
+					logger.info("Milestone '{}' exists; ignore", version.getName());
+				}
+			}
 		}
 		tracker.stopProgress();
 	}
@@ -220,7 +233,19 @@ public class  MigrationClient {
 		for (Map<String, String> map : labels) {
 			tracker.updateForIteration();
 			logger.debug("Creating label: \"{}\"", map);
-			getRest().exchange(bodyBuilder.body(map), MAP_TYPE);
+			try {
+				getRest().exchange(bodyBuilder.body(map), MAP_TYPE);
+			}
+			catch (HttpClientErrorException.UnprocessableEntity ex) {
+				// The milestone already exists on GH, so swallow its error and continue
+				if (ex.getMessage() != null && !ex.getMessage().contains("already_exists")) {
+					throw ex;
+				}
+				else {
+					logger.info("Label '{}' exists; ignore", map.get("name"));
+				}
+			}
+
 		}
 		tracker.stopProgress();
 	}
@@ -640,11 +665,17 @@ public class  MigrationClient {
 		GithubIssue ghIssue = new GithubIssue();
 		ghIssue.setMilestone((Integer) milestone.get("number"));
 		ghIssue.setTitle(milestone.get("title") + " Backported Issues");
-		DateTime dueOnDateTime = this.dateTimeFormatter.parseDateTime((String) milestone.get("due_on"));
-		ghIssue.setCreatedAt(dueOnDateTime);
+		DateTime dueOnDateTime = null;
+		String due_on = (String) milestone.get("due_on");
+		if (StringUtils.hasText(due_on)) {
+			dueOnDateTime = this.dateTimeFormatter.parseDateTime(due_on);
+			ghIssue.setCreatedAt(dueOnDateTime);
+		}
 		if (milestone.get("state").equals("closed")) {
 			ghIssue.setClosed(true);
-			ghIssue.setClosedAt(dueOnDateTime);
+			if (dueOnDateTime != null) {
+				ghIssue.setClosedAt(dueOnDateTime);
+			}
 		}
 		String body = backportIssues.stream()
 				.map(jiraIssue -> {

--- a/src/main/java/io/pivotal/migration/SiMigrationConfig.java
+++ b/src/main/java/io/pivotal/migration/SiMigrationConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.migration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.pivotal.github.GithubIssue;
+import io.pivotal.github.ImportGithubIssue;
+import io.pivotal.jira.JiraFixVersion;
+import io.pivotal.jira.JiraIssue;
+import io.pivotal.migration.FieldValueLabelHandler.FieldType;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * Configuration for migration of Spring Integration JIRA.
+ */
+@Configuration
+@ConditionalOnProperty(name = "jira.projectId", havingValue = "INT")
+public class SiMigrationConfig {
+
+	private static final List<String> skipVersions =
+			Arrays.asList("Pending Closure", "Waiting for Triage");
+
+
+	@Bean
+	public MilestoneFilter milestoneFilter() {
+		return fixVersion -> !skipVersions.contains(fixVersion.getName());
+	}
+
+	@Bean
+	public LabelHandler labelHandler() {
+		FieldValueLabelHandler fieldValueHandler = new FieldValueLabelHandler();
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Adapters", "core", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "AMQP Support", "amqp", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Async HTTP Support", "http", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Build", "build", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Core", "core", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "DSL", "dsl", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Event Support", "events", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Feed Support", "feed", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "File Support", "file", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "FTP/SFTP Support", "ftp", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "GemFire Support", "gemfire", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Groovy Support", "groovy", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "HTTP Support", "http", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "JDBC Support", "jdbc", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "JMS Support", "jms", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "JMX Support", "jmx", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "JPA Support", "jpa", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Mail Support", "mail", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "MongoDB Support", "mongodb", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "MQTT Support", "mqtt", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Pattern Catalog", "core", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "R2DBC", "r2dbc", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Redis Support", "redis", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "RMI Support", "rmi", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Scripting Support", "scripting", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Security", "security", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "STOMP Support", "stomp", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Stream Support", "stream", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Syslog Support", "syslog", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "TCP/UDP Support", "TCP/UDP", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Testing", "testing", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Twitter Support", "twitter", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Web Services", "ws", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "WebFlux Support", "webflux", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "WebSocket Support", "websocket", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "XML", "xml", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "XMPP Support", "xmpp", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Zookeeper Support", "zookeeper", SiMigrationConfig::componentLabel);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Samples", "documentation", LabelFactories.TYPE_LABEL);
+		fieldValueHandler.addMapping(FieldType.COMPONENT, "Documentation", "documentation", LabelFactories.TYPE_LABEL);
+
+		// "Build System" - not used
+
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Bug", "bug");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Defect", "bug");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "New Feature", "enhancement");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Improvement", "enhancement");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Refactoring", "refactoring");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Pruning", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Task", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Sub-task", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Story", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Epic", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Technical task", "task");
+		fieldValueHandler.addMapping(FieldType.ISSUE_TYPE, "Support", "task");
+		// "Backport" - ignore
+
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Deferred", "declined", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Won't Do", "declined", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Won't Fix", "declined", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Works as Designed", "declined", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Duplicate", "duplicate", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Invalid", "invalid", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Incomplete", "invalid", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.RESOLUTION, "Cannot Reproduce", "invalid", SiMigrationConfig::statusLabel);
+		// "Complete", "Fixed", "Done" - it should be obvious if it has fix version and is closed
+
+		fieldValueHandler.addMapping(FieldType.STATUS, "Waiting for Feedback", "waiting-for-reporter", SiMigrationConfig::statusLabel);
+		// "Resolved", "Closed -- it should be obvious if issue is closed (distinction not of interest)
+		// "Open", "Re Opened" -- it should be obvious from GH timeline
+		// "In Progress", "Investigating" -- no value in those, they don't work well
+
+		fieldValueHandler.addMapping(FieldType.VERSION, "Waiting for Triage", "waiting-for-triage", SiMigrationConfig::statusLabel);
+		fieldValueHandler.addMapping(FieldType.VERSION, "Waiting For Diagnostics", "waiting-for-triage", SiMigrationConfig::statusLabel);
+
+		fieldValueHandler.addMapping(FieldType.LABEL, "Regression", "regression", LabelFactories.TYPE_LABEL);
+
+
+		CompositeLabelHandler handler = new CompositeLabelHandler();
+		handler.addLabelHandler(fieldValueHandler);
+
+		handler.addLabelHandler(LabelFactories.STATUS_LABEL.apply("waiting-for-triage"), issue ->
+				issue.getFields().getResolution() == null && issue.getFixVersion() == null);
+
+		handler.addLabelHandler(LabelFactories.HAS_LABEL.apply("votes-jira"), issue ->
+				issue.getVotes() >= 10);
+
+		handler.addLabelHandler(LabelFactories.HAS_LABEL.apply("backports"), issue ->
+				!issue.getBackportVersions().isEmpty());
+
+		handler.addLabelSupersede("type: bug", "type: regression");
+		handler.addLabelSupersede("type: task", "type: documentation");
+		handler.addLabelSupersede("status: waiting-for-triage", "status: waiting-for-feedback");
+
+		// In Jira users pick the type when opening ticket. It doesn't work that way in GitHub.
+		handler.addLabelRemoval("status: waiting-for-triage", label -> label.startsWith("type: "));
+		// If it is invalid, the issue type is undefined
+		handler.addLabelRemoval("status: invalid", label -> label.startsWith("type: "));
+		// Anything declined is not a bug nor regression
+		handler.addLabelRemoval("status: declined",  label -> label.equals("type: bug"));
+		handler.addLabelRemoval("status: declined",  label -> label.equals("type: regression"));
+		// No need to label an issue with bug or regression if it is a duplicate
+		handler.addLabelRemoval("status: duplicate", label -> label.equals("type: bug"));
+		handler.addLabelRemoval("status: duplicate", label -> label.equals("type: regression"));
+
+		return handler;
+	}
+
+	private static Map<String, String> componentLabel(String labelName) {
+		Map<String, String> label = LabelFactories.IN_LABEL.apply(labelName);
+		label.put("color", "27ddc8");
+		return label;
+	}
+
+	private static Map<String, String> statusLabel(String labelName) {
+		Map<String, String> label = LabelFactories.STATUS_LABEL.apply(labelName);
+		label.put("color", "5319e7");
+		return label;
+	}
+
+	@Bean
+	public IssueProcessor issueProcessor() {
+		return new CompositeIssueProcessor(new AssigneeDroppingIssueProcessor());
+	}
+
+
+	private static class AssigneeDroppingIssueProcessor implements IssueProcessor {
+
+		private static final String label1 = LabelFactories.STATUS_LABEL.apply("waiting-for-triage").get("name");
+
+		private static final String label2 = LabelFactories.STATUS_LABEL.apply("ideal-for-contribution").get("name");
+
+
+		@Override
+		public void beforeImport(JiraIssue issue, ImportGithubIssue importIssue) {
+			JiraFixVersion version = issue.getFixVersion();
+			GithubIssue ghIssue = importIssue.getIssue();
+			if (version != null && version.getName().contains("Backlog") ||
+					ghIssue.getLabels().contains(label1) ||
+					ghIssue.getLabels().contains(label2)) {
+
+				ghIssue.setAssignee(null);
+			}
+		}
+	}
+
+}

--- a/src/main/java/io/pivotal/pre/AssigneesReport.java
+++ b/src/main/java/io/pivotal/pre/AssigneesReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,12 @@ import io.pivotal.jira.JiraUser;
  * src/main/resources/jira-to-github-users.properties.
  *
  * @author Rossen Stoyanchev
+ * @author Artem Bilan
  */
 public class AssigneesReport extends BaseApp {
 
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 
 		JiraConfig config = initJiraConfig();
 		JiraClient client = new JiraClient(config);
@@ -50,11 +51,11 @@ public class AssigneesReport extends BaseApp {
 			}
 		}
 
-		List<String> assignees = result.entrySet().stream()
+		String assignees = result.entrySet().stream()
 				.map(entry -> entry.getKey() + " [" + entry.getValue().get() + "]")
-				.collect(Collectors.toList());
+				.collect(Collectors.joining(System.lineSeparator()));
 
-		System.out.println("Assignees: \n" + assignees + "\n\n");
+		System.out.println("Assignees: \n" + assignees);
 	}
 
 }

--- a/src/main/java/io/pivotal/pre/MigrationConfigReport.java
+++ b/src/main/java/io/pivotal/pre/MigrationConfigReport.java
@@ -32,15 +32,16 @@ import io.pivotal.jira.JiraVersion;
  * {@link io.pivotal.migration.SwfMigrationConfig}.
  *
  * @author Rossen Stoyanchev
+ * @author Artme Bilan
  */
 public class MigrationConfigReport extends BaseApp {
 
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 
 		JiraConfig config = initJiraConfig();
 		JiraClient client = new JiraClient(config);
-		JiraProject project = client.findProject("SWF");
+		JiraProject project = client.findProject(config.getProjectId());
 
 		System.out.println("Components: \n" +
 				project.getComponents().stream().map(JiraComponent::getName).collect(Collectors.joining("\n")) +

--- a/src/main/java/io/pivotal/util/MarkdownEngine.java
+++ b/src/main/java/io/pivotal/util/MarkdownEngine.java
@@ -118,7 +118,7 @@ public class MarkdownEngine implements MarkupEngine {
 
 		// Code
 		text = text.replaceAll("\\{\\{(.+?)\\}\\}", "`$1`"); // inline code
-		text = text.replaceAll("\\{(code|noformat|panel)(:(\\w+))?(?:(:|\\|)\\w+=.+?)*\\}", "```$3 ");
+		text = text.replaceAll("(?i)\\{(code|noformat|panel)(:(\\w+))?(?:(:|\\|)\\w+=.+?)*\\}", "```$3 ");
 		text = text.replaceAll("(```\\w*) (.+)", "$1\n$2");
 		text = text.replaceAll("(.)(```) ", "$1\n$2");
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,8 @@ jira.base-url=https://jira.spring.io
 # The JIRA project id to migrate. For example, "SEC".
 #jira.projectId=SPR
 #jira.projectId=SEC
-jira.projectId=SWF
+#jira.projectId=SWF
+jira.projectId=INT
 
 ##
 # The github repository slug to migrate to. For example, to migrate the
@@ -30,7 +31,8 @@ jira.projectId=SWF
 #github.repository-slug=rstoyanchev/spr-issue-migration-test
 #github.repository-slug=rwinch/spring-security-migrate-issues
 #github.repository-slug=rstoyanchev/swf-migration-test
-github.repository-slug=spring-projects/spring-webflow
+#github.repository-slug=spring-projects/spring-webflow
+github.repository-slug=spring-projects/spring-integration
 
 ##
 # If set, the migration script will attempt to delete / create a GitHub
@@ -47,6 +49,6 @@ github.delete-create-repository-slug=false
 #jira.migrate-jql=project\=SWF AND created>2015-01-01
 
 ##
-# Includes the local profile. This allows for placing the OAuth token in application-local.properties so it is not
-# accidentally pushed to any remotes.
+# Includes the local profile. This allows for placing the OAuth token in application-local.properties,
+# so it is not accidentally pushed to any remotes.
 spring.profiles.active=local

--- a/src/main/resources/jira-to-github-users.properties
+++ b/src/main/resources/jira-to-github-users.properties
@@ -52,4 +52,14 @@
 # Spring Web Flow migration
 # ==========================
 
-rstoya05-aop:rstoyanchev
+#rstoya05-aop:rstoyanchev
+
+# ==========================
+# Spring Integration migration
+# ==========================
+
+abilan:artembilan
+mark.fisher:markfisher
+tmarshall:trevormarshall
+david_syer:dsyer
+grussell:garyrussell

--- a/src/test/java/io/pivotal/util/MarkdownEngineTests.java
+++ b/src/test/java/io/pivotal/util/MarkdownEngineTests.java
@@ -602,6 +602,29 @@ public class MarkdownEngineTests {
 	}
 
 	@Test
+	public void blockCodeUpperCase() {
+		String body =
+				"{CODE:xml}\n" +
+						"    <filter-mapping>\n" +
+						"      <filter-name>springSecurityFilterChain</filter-name>\n" +
+						"      <url-pattern>/*</url-pattern>\n" +
+						"      <dispatcher>REQUEST</dispatcher>\n" +
+						"      <dispatcher>FORWARD</dispatcher>\n" +
+						"    </filter-mapping>\n{CODE}";
+
+		String convert = engine.convert(body);
+		assertThat(convert).isEqualTo(
+				"```xml\n" +
+						"<filter-mapping>\n" +
+						"  <filter-name>springSecurityFilterChain</filter-name>\n" +
+						"  <url-pattern>/*</url-pattern>\n" +
+						"  <dispatcher>REQUEST</dispatcher>\n" +
+						"  <dispatcher>FORWARD</dispatcher>\n" +
+						"</filter-mapping>\n" +
+						"```\n\n");
+	}
+
+	@Test
 	public void blockCodeNoNewLineAfterOrBefore() {
 		String body =
 				"{code}" +


### PR DESCRIPTION
* Upgrade to `flexmark-all-0.35.10`. Tried to the latest one, but then `MarkdownEngine` messes up with links on a second phase: wraps already correct GH links into `[]`
* Add `INT` JIRA project handling into `application.properties`
* Modify `AssigneesReport` to output result items each from new line for better readability
* Use `AssigneesReport` result to populated `jira-to-github-users.properties` for Spring Integration
* Fix `JiraConfig` to wrap project id into quotes since `INT` is a reserved SQL word
* Add `SiMigrationConfig` for labels mapping
* Fix `MigrationConfigReport` to take a project id from the config
* Fix `MarkdownEngine` to ignore case for `code`, `noformat` and `panel` JIRA blocks
* Ignore `HttpClientErrorException.UnprocessableEntity` with an `already_exists` status for labels and milestones on GH side.
* Fix NPE about `due_on` from JIRA milestones with just leaving the respective GH issue property empty